### PR TITLE
Implementing directives instead of plugins

### DIFF
--- a/server/rateLimiter.ts
+++ b/server/rateLimiter.ts
@@ -1,14 +1,71 @@
-let count: number = 5;
+const { ApolloServer, SchemaDirectiveVisitor } = require('apollo-server');
+import {
+  defaultFieldResolver,
+  GraphQLField,
+  GraphQLObjectType,
+  GraphQLResolveInfo,
+  GraphQLError,
+} from 'graphql';
 
-export const rateLimiter = (requestContext: any, responseContext: any, options: any = {
-  requestLimit: 10,
-  throttleSetting: null,
-  timer: 20,
-}) => {
-  count++;
-  console.log(requestContext.context.req.ip)
-  if (count >= options.requestLimit) {
-    throw new Error(`Request limit exceeded. Try again in ${options.timer} minutes`)
+// let count: number = 5;
+
+// export const rateLimiter = (requestContext: any, responseContext: any, options: any = {
+//   requestLimit: 10,
+//   throttleSetting: null,
+//   timer: 20,
+// }) => {
+//   count++;
+//   console.log(requestContext.context.req.ip)
+//   if (count >= options.requestLimit) {
+//     throw new Error(`Request limit exceeded. Try again in ${options.timer} minutes`)
+//   }
+//   console.log(count)
+// }
+
+const rateLimiter = (limit: number) => {
+  let count: number = 0;
+  return function () {
+    if (count === limit) {
+      throw new Error("nope, you've exceeded your requests");
+    }
+    count += 1;
+    console.log(count);
+  };
+};
+
+export class portaraSchemaDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field: GraphQLField<any, any>, details) {
+    // console.log(field.astNode.directives[0].name);
+    const { limit } = this.args;
+    const fields = details.objectType.getFields();
+
+    const variables = {};
+    for (let field in fields) {
+      variables[field] = fields[field].resolve;
+      variables[`rateLimiter-${field}`] = rateLimiter(limit);
+    }
+
+    field.resolve = (object, args, context, info) => {
+      // console.log('FIELD: ', field);
+      variables[`rateLimiter-${info.fieldName}`]();
+      return variables[info.fieldName]();
+    };
   }
-  console.log(count)
+  visitObject(type: GraphQLObjectType) {
+    const { limit } = this.args;
+    const fields = type.getFields();
+
+    const variables = {};
+    const func = rateLimiter(limit);
+
+    Object.values(fields).forEach((field) => {
+      if (!field.astNode!.directives!.some((directive) => directive.name.value === 'portara')) {
+        variables[field.name] = field.resolve;
+        field.resolve = (object, args, context, info) => {
+          func();
+          return variables[field.name]();
+        };
+      }
+    });
+  }
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,15 +2,18 @@ const express = require('express');
 const graphql = require('graphql')
 const { ApolloServer } = require('apollo-server-express');
 const { gql } = require('apollo-server');
-import { rateLimiter } from './rateLimiter'
+// import { rateLimiter } from './rateLimiter'
+import { portaraSchemaDirective } from './rateLimiter'
 
 // Types
 const typeDefs = gql`
+  directive @portara(limit: Int!) on FIELD_DEFINITION | OBJECT
+
   type Query {
     test: String!
   }, 
-  type Mutation {
-    hello: String!
+  type Mutation @portara(limit: 2) {
+    hello: String! 
   }, 
 `;
  
@@ -18,7 +21,6 @@ const typeDefs = gql`
 const resolvers = {
   Mutation: {
     hello: (parent, args, context, info) => {
-      // console.log(context.req.body)
       return 'Request completed and returned'
     }
   },
@@ -31,13 +33,16 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   context: ({req, res}) => ({req, res}),
-  plugins: [
-    {
-      requestDidStart(requestContext, responseContext) {
-        rateLimiter(requestContext, responseContext)
-      },   
-    }
-  ]
+  // plugins: [
+  //   {
+  //     requestDidStart(requestContext, responseContext) {
+  //       rateLimiter(requestContext, responseContext)
+  //     },   
+  //   }
+  // ],
+  schemaDirectives: {
+    portara: portaraSchemaDirective,
+  },
 })
 
 server.applyMiddleware({


### PR DESCRIPTION
**Problem**
- Previous solution was using Apollo Plugins for an easy MVP. The approach would have worked fine, but it seemed like digging into directives could be a better approach.

**Solution**
- Using directives, this approach implements functionality where the host can choose what they want to rate limit. This pull request includes the options of either putting the rate limiter on the FIELD itself, or on an entire OBJECT (for example, all mutations). 

**To test**
- Inside of rateLimiter you can find all the added functionality. I've added the directive to the top of the typeDefs inside of the server file, and then also added it directly on the field in the mutation. Test by going to localhost:4000/graphql and run the mutation. The console in the code editor will show count incrementing