### PR TITLE
Adds a working version for schema level directive

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -7,15 +7,21 @@ import { portaraSchemaDirective } from './rateLimiter'
 
 // Types
 const typeDefs = gql`
-  directive @portara(limit: Int!) on FIELD_DEFINITION | OBJECT
+  directive @portara(limit: Int!) on FIELD_DEFINITION | OBJECT | SCHEMA
+
+  schema  @portara(limit: 25) {
+    query: Query
+    mutation: Mutation
+  }
 
   type Query {
     test: String!
-  }, 
-  type Mutation @portara(limit: 20) {
-    hello: String! #@portara(limit: 2)
+  }
+
+  type Mutation {
+    hello: String! # @portara(limit: 2)
     bye: String! #@portara(limit: 2)
-  }, 
+  }
 `;
  
 // Resolvers


### PR DESCRIPTION
**Problem**
- Wanted to be able to apply @portara to entire schema, not just individual objects or fields

**Solution**
- Found a way to apply it to entire schema as long as the schema is defined in the typeDefs. Current solution also lets you apply @portara to individual fields without overlap.

**To Test**
- Current request includes portara on the schema level, so just start the server @ 4000, go to the playground and run some queries