### PR TITLE
Reverted to only using Object and Field level

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -6,22 +6,23 @@ const { gql } = require('apollo-server');
 import { portaraSchemaDirective } from './rateLimiter';
 // Types
 const typeDefs = gql`
-  directive @portara(limit: Int!) on FIELD_DEFINITION | OBJECT | SCHEMA
+  directive @portara(limit: Int!) on FIELD_DEFINITION | OBJECT 
 
-  schema @portara(limit: 8) {
-    query: Query
-    mutation: Mutation
-  }
   type Query {
     test: String!
   }
-  type Mutation @portara(limit: 6) {
-    hello: String! #@portara(limit: 8)
+  type Mutation  @portara(limit: 8){
+    hello: String! @portara(limit: 2)
     bye: String! #@portara(limit: 2)
   }
 `;
 // Resolvers
 const resolvers = {
+  Query: {
+    test: (parent, args, context, info) => {
+      return 'Test'
+    }
+  },
   Mutation: {
     hello: (parent, args, context, info) => {
       return 'Request completed and returned';


### PR DESCRIPTION
**Problem**
- Being able to add @portara to the entire schema is hard without creating conflicts with object level. It works, but it means that two resolvers will get run for any given field, which creates issues on multiple levels.
**Solution**
- For now, going back to only using field and object directives. Shouldn't be a problem in terms of user experience. Current version works with Redis and expiration times.
**To test**
- Run local at 4000 and try applying directives on various fields/object. 