### PR TITLE
Testing

### DIFF
--- a/server/__tests__/rateLimit.test.ts
+++ b/server/__tests__/rateLimit.test.ts
@@ -79,7 +79,6 @@ describe('Rate Limiter accepts various timeframe values', () => {
   })
 })
 
-// describe('rate limit test?', async () => {
 describe('rate limit test using @portara decorator', () => {
   beforeAll(async () => {
     if (client.status === "end") {
@@ -152,4 +151,3 @@ describe('rate limit test using @portara decorator', () => {
     expect(response6.errors![0].message).toContain('You have exceeded');
   })
 })
-// })

--- a/server/__tests__/rateLimit.test.ts
+++ b/server/__tests__/rateLimit.test.ts
@@ -1,7 +1,7 @@
 import { graphql } from 'graphql'
 import { gql, SchemaDirectiveVisitor } from 'apollo-server'
 import { makeExecutableSchema, IResolverValidationOptions } from 'graphql-tools'
-import { portaraSchemaDirective, rateLimiter } from '../rateLimiter';
+import { portaraSchemaDirective, rateLimiter, timeFrameMultiplier } from '../rateLimiter';
 
 // Globally allows resolvers to not exist in the original schema
 const resolverValidationOptions: IResolverValidationOptions = {
@@ -65,3 +65,17 @@ describe('Receives a response from our GraphQL Query', () => {
   })
 })
 
+describe('Rate Limiter accepts various timeframe values', () => {
+  it('returns an error when input value is not recognized', () => {
+    const timeframe = timeFrameMultiplier('years')
+    expect(timeframe).toBeInstanceOf(Error)
+  })
+
+  it('defaults to 1 second when value is an empty string', ()=> {
+    const timeframe = timeFrameMultiplier('')
+    expect(timeframe).toEqual(1000)
+  })
+
+
+
+})

--- a/server/rateLimiter.ts
+++ b/server/rateLimiter.ts
@@ -80,7 +80,6 @@ export class portaraSchemaDirective extends SchemaDirectiveVisitor {
         return new Error(error)
       };
     };
-
   }
 
   visitObject(type: GraphQLObjectType) {


### PR DESCRIPTION
Problem: timeFrameMultiplier lived inside of rateLimiter and was untested
Solution: moved timeFrame Multiplier out of rateLimiter function and tested it with undefined and default edge-cases.
Tested: all 8 tests passed after merging w/ latest pull, server and client side both run successfully.