### PR TITLE
Directive applications tested on Jest to see if the directives were a…

### DIFF
--- a/server/rateLimiter.ts
+++ b/server/rateLimiter.ts
@@ -31,25 +31,25 @@ export const timeFrameMultiplier = (timeFrame) => {
 // Redis Rate Limiter -------------------------------------------
 export const rateLimiter = async (limit: number, per: string, ip: string, scope: string) => {
 
-  const timeFrameMultiplier = (timeFrame) => {
-    if (timeFrame === 'milliseconds' || timeFrame === 'millisecond' || timeFrame === 'mil' || timeFrame === 'mils' || timeFrame === 'ms') {
-      return 1
-    } else if (timeFrame === 'seconds' || timeFrame === 'second' || timeFrame === 'sec' || timeFrame === 'secs' || timeFrame === 's') {
-      return 1000;
-    } else if (timeFrame === 'minutes' || timeFrame === 'minute' || timeFrame === 'min' || timeFrame === 'mins' || timeFrame === 'm') {
-      return 1000 * 60;
-    } else if (timeFrame === 'hours' || timeFrame === 'hour' || timeFrame === 'h') {
-      return 1000 * 60 * 60;
-    } else if (timeFrame === 'days' || timeFrame === 'day' || timeFrame === 'd') {
-      return 1000 * 60 * 60 * 24;
-    } else if (timeFrame === 'weeks' || timeFrame === 'week' || timeFrame === 'w') {
-      return 1000 * 60 * 60 * 24 * 7;
-    } else if (timeFrame === '' || timeFrame === undefined) {
-      return 1000;
-    } else {
-      return new Error('Not a valid measurement of time!');
-    }
-  }
+  // const timeFrameMultiplier = (timeFrame) => {
+  //   if (timeFrame === 'milliseconds' || timeFrame === 'millisecond' || timeFrame === 'mil' || timeFrame === 'mils' || timeFrame === 'ms') {
+  //     return 1
+  //   } else if (timeFrame === 'seconds' || timeFrame === 'second' || timeFrame === 'sec' || timeFrame === 'secs' || timeFrame === 's') {
+  //     return 1000;
+  //   } else if (timeFrame === 'minutes' || timeFrame === 'minute' || timeFrame === 'min' || timeFrame === 'mins' || timeFrame === 'm') {
+  //     return 1000 * 60;
+  //   } else if (timeFrame === 'hours' || timeFrame === 'hour' || timeFrame === 'h') {
+  //     return 1000 * 60 * 60;
+  //   } else if (timeFrame === 'days' || timeFrame === 'day' || timeFrame === 'd') {
+  //     return 1000 * 60 * 60 * 24;
+  //   } else if (timeFrame === 'weeks' || timeFrame === 'week' || timeFrame === 'w') {
+  //     return 1000 * 60 * 60 * 24 * 7;
+  //   } else if (timeFrame === '' || timeFrame === undefined) {
+  //     return 1000;
+  //   } else {
+  //     return new Error('Not a valid measurement of time!');
+  //   }
+  // }
 
   // Per Functionality ---------------------------
 


### PR DESCRIPTION
Problem: Deep diving into the schemaDirectiveVisitor to find where the directives are applied to our resolvers on the FIELD_DEFINITION and OBJECT.

Solution: Console logged to find where the directive lives after being applied to our resolvers.  Reading typeDefs object, we were able to find where our directive would be applied on both the FIELD_DEFINITION and OBJECT exists.