### PR TITLE
Refining rate limiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portara",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "description": "Portara",
   "main": "index.js",
   "scripts": {

--- a/server/__tests__/rateLimit.test.ts
+++ b/server/__tests__/rateLimit.test.ts
@@ -1,7 +1,8 @@
 import { graphql } from 'graphql'
 const { gql, makeExecutableSchema } = require('apollo-server')
 import { IResolverValidationOptions } from 'graphql-tools'
-import { portaraSchemaDirective, timeFrameMultiplier } from '../rateLimiter';
+import timeFrameMultiplier from '../portara/timeFrameMultiplier';
+import portaraSchemaDirective from '../portara/portaraSchemaDirective'
 const asyncRedis = require('async-redis');
 const client = asyncRedis.createClient();
 
@@ -76,17 +77,17 @@ describe('Rate Limiter accepts various timeframe values', () => {
   })
 
 
-  it('defaults to 1 second when value is an empty string or undefined', ()=> {
+  it('defaults to 1 second when value is an empty string or undefined', () => {
     const timeFrame = timeFrameMultiplier(undefined || '')
     expect(timeFrame).toEqual(1000)
   })
 
-  it('converts hours into milliseconds if the input is hours', ()=> {
+  it('converts hours into milliseconds if the input is hours', () => {
     const timeFrame = timeFrameMultiplier('hours')
     expect(timeFrame).toEqual(3600000)
   })
 
-  it('converts days into milliseconds if the input is days', ()=> {
+  it('converts days into milliseconds if the input is days', () => {
     const timeFrame = timeFrameMultiplier('days')
     expect(timeFrame).toEqual(86400000)
 

--- a/server/examples/server.ts
+++ b/server/examples/server.ts
@@ -1,5 +1,5 @@
 const { ApolloServer, gql } = require('apollo-server');
-import { portaraSchemaDirective } from '../rateLimiter';
+import { portaraSchemaDirective } from '../portara/rateLimiter';
 
 // typeDefs
 const typeDefs = gql`

--- a/server/portara/portaraDirective.ts
+++ b/server/portara/portaraDirective.ts
@@ -1,0 +1,54 @@
+const { SchemaDirectiveVisitor }: any = require('graphql-tools');
+import {
+  defaultFieldResolver,
+  GraphQLField,
+  GraphQLObjectType,
+} from 'graphql';
+const asyncRedis = require('async-redis');
+const client = asyncRedis.createClient();
+import rateLimiter from './rateLimiter'
+
+export class portaraSchemaDirective extends SchemaDirectiveVisitor {
+
+  async generateErrorMessage(limit, per, name, ip) {
+    const timeLeft = await client.ttl(`${ip}_${name}`)
+    let error = `You have exceeded the request limit of ${limit} for the type(s) '${name}' . You have ${timeLeft} seconds left until the next request can be made.`;
+    return error;
+  }
+
+  visitFieldDefinition(field: GraphQLField<any, any>, details) {
+    const { limit, per } = this.args;
+    const { resolve = defaultFieldResolver } = field;
+    field.resolve = async (...originalArgs) => {
+      const [object, args, context, info] = originalArgs;
+      const error = await this.generateErrorMessage(limit, per, info.fieldName, context.req.ip)
+      const underLimit = await rateLimiter(limit, per, context.req.ip, info.fieldName);
+      if (underLimit) {
+        return resolve(...originalArgs);
+      } else {
+        const error = await this.generateErrorMessage(limit, per, info.fieldName, context.req.ip)
+        return new Error(error)
+      };
+    };
+  }
+
+  visitObject(type: GraphQLObjectType) {
+    const { limit, per } = this.args;
+    const fields = type.getFields();
+    Object.values(fields).forEach((field) => {
+      const { resolve = defaultFieldResolver } = field;
+      if (!field.astNode!.directives!.some((directive) => directive.name.value === 'portara')) {
+        field.resolve = async (...originalArgs) => {
+          const [object, args, context, info] = originalArgs;
+          const underLimit = await rateLimiter(limit, per, context.req.ip, type.toString());
+          if (underLimit) {
+            return resolve(...originalArgs);
+          } else {
+            const error = await this.generateErrorMessage(limit, per, type.toString(), context.req.ip)
+            return new Error(error)
+          };
+        };
+      }
+    });
+  }
+}

--- a/server/portara/rateLimiter.ts
+++ b/server/portara/rateLimiter.ts
@@ -7,49 +7,10 @@ import {
 
 const asyncRedis = require('async-redis');
 const client = asyncRedis.createClient();
-
-export const timeFrameMultiplier = (timeFrame) => {
-  if (timeFrame === 'milliseconds' || timeFrame === 'millisecond' || timeFrame === 'mil' || timeFrame === 'mils' || timeFrame === 'ms') {
-    return 1
-  } else if (timeFrame === 'seconds' || timeFrame === 'second' || timeFrame === 'sec' || timeFrame === 'secs' || timeFrame === 's') {
-    return 1000;
-  } else if (timeFrame === 'minutes' || timeFrame === 'minute' || timeFrame === 'min' || timeFrame === 'mins' || timeFrame === 'm') {
-    return 1000 * 60;
-  } else if (timeFrame === 'hours' || timeFrame === 'hour' || timeFrame === 'h') {
-    return 1000 * 60 * 60;
-  } else if (timeFrame === 'days' || timeFrame === 'day' || timeFrame === 'd') {
-    return 1000 * 60 * 60 * 24;
-  } else if (timeFrame === 'weeks' || timeFrame === 'week' || timeFrame === 'w') {
-    return 1000 * 60 * 60 * 24 * 7;
-  } else if (timeFrame === '' || timeFrame === undefined) {
-    return 1000;
-  } else {
-    return new Error('Not a valid measurement of time!');
-  }
-}
+import timeFrameMultiplier from './timeFrameMultiplier'
 
 // Redis Rate Limiter -------------------------------------------
 export const rateLimiter = async (limit: number, per: string, ip: string, scope: string) => {
-
-  // const timeFrameMultiplier = (timeFrame) => {
-  //   if (timeFrame === 'milliseconds' || timeFrame === 'millisecond' || timeFrame === 'mil' || timeFrame === 'mils' || timeFrame === 'ms') {
-  //     return 1
-  //   } else if (timeFrame === 'seconds' || timeFrame === 'second' || timeFrame === 'sec' || timeFrame === 'secs' || timeFrame === 's') {
-  //     return 1000;
-  //   } else if (timeFrame === 'minutes' || timeFrame === 'minute' || timeFrame === 'min' || timeFrame === 'mins' || timeFrame === 'm') {
-  //     return 1000 * 60;
-  //   } else if (timeFrame === 'hours' || timeFrame === 'hour' || timeFrame === 'h') {
-  //     return 1000 * 60 * 60;
-  //   } else if (timeFrame === 'days' || timeFrame === 'day' || timeFrame === 'd') {
-  //     return 1000 * 60 * 60 * 24;
-  //   } else if (timeFrame === 'weeks' || timeFrame === 'week' || timeFrame === 'w') {
-  //     return 1000 * 60 * 60 * 24 * 7;
-  //   } else if (timeFrame === '' || timeFrame === undefined) {
-  //     return 1000;
-  //   } else {
-  //     return new Error('Not a valid measurement of time!');
-  //   }
-  // }
 
   // Per Functionality ---------------------------
 

--- a/server/portara/rateLimiter.ts
+++ b/server/portara/rateLimiter.ts
@@ -1,22 +1,13 @@
-const { SchemaDirectiveVisitor }: any = require('apollo-server');
-import {
-  defaultFieldResolver,
-  GraphQLField,
-  GraphQLObjectType,
-} from 'graphql';
-
 const asyncRedis = require('async-redis');
 const client = asyncRedis.createClient();
 import timeFrameMultiplier from './timeFrameMultiplier'
 
 // Redis Rate Limiter -------------------------------------------
-export const rateLimiter = async (limit: number, per: string, ip: string, scope: string) => {
+const rateLimiter = async (limit: number, per: string, ip: string, scope: string) => {
 
   // Per Functionality ---------------------------
-
   const perNum = parseFloat(<any>per.match(/\d+/g)?.toString())
   const perWord = per.match(/[a-zA-Z]+/g)?.toString().toLowerCase();
-
 
   // get final result of expirationTimeVariable
   let expirationTimeVariable = (<number>timeFrameMultiplier(perWord) * perNum);
@@ -36,51 +27,5 @@ export const rateLimiter = async (limit: number, per: string, ip: string, scope:
     return value > limit ? false : true;
   }
 };
-//---------------------------------------------------------------
 
-export class portaraSchemaDirective extends SchemaDirectiveVisitor {
-
-  async generateErrorMessage(limit, per, name, ip) {
-    const timeLeft = await client.ttl(`${ip}_${name}`)
-    let error = `You have exceeded the request limit of ${limit} for the type(s) '${name}' . You have ${timeLeft} seconds left until the next request can be made.`;
-    return error;
-  }
-
-
-
-  visitFieldDefinition(field: GraphQLField<any, any>, details) {
-    const { limit, per } = this.args;
-    const { resolve = defaultFieldResolver } = field;
-    field.resolve = async (...originalArgs) => {
-      const [object, args, context, info] = originalArgs;
-      const error = await this.generateErrorMessage(limit, per, info.fieldName, context.req.ip)
-      const underLimit = await rateLimiter(limit, per, context.req.ip, info.fieldName);
-      if (underLimit) {
-        return resolve(...originalArgs);
-      } else {
-        const error = await this.generateErrorMessage(limit, per, info.fieldName, context.req.ip)
-        return new Error(error)
-      };
-    };
-  }
-
-  visitObject(type: GraphQLObjectType) {
-    const { limit, per } = this.args;
-    const fields = type.getFields();
-    Object.values(fields).forEach((field) => {
-      const { resolve = defaultFieldResolver } = field;
-      if (!field.astNode!.directives!.some((directive) => directive.name.value === 'portara')) {
-        field.resolve = async (...originalArgs) => {
-          const [object, args, context, info] = originalArgs;
-          const underLimit = await rateLimiter(limit, per, context.req.ip, type.toString());
-          if (underLimit) {
-            return resolve(...originalArgs);
-          } else {
-            const error = await this.generateErrorMessage(limit, per, type.toString(), context.req.ip)
-            return new Error(error)
-          };
-        };
-      }
-    });
-  }
-}
+export default rateLimiter;

--- a/server/portara/throttler.ts
+++ b/server/portara/throttler.ts
@@ -1,0 +1,3 @@
+export default function throttler(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/server/portara/timeFrameMultiplier.ts
+++ b/server/portara/timeFrameMultiplier.ts
@@ -1,0 +1,19 @@
+export default function timeFrameMultiplier(timeFrame) {
+  if (timeFrame === 'milliseconds' || timeFrame === 'millisecond' || timeFrame === 'mil' || timeFrame === 'mils' || timeFrame === 'ms') {
+    return 1
+  } else if (timeFrame === 'seconds' || timeFrame === 'second' || timeFrame === 'sec' || timeFrame === 'secs' || timeFrame === 's') {
+    return 1000;
+  } else if (timeFrame === 'minutes' || timeFrame === 'minute' || timeFrame === 'min' || timeFrame === 'mins' || timeFrame === 'm') {
+    return 1000 * 60;
+  } else if (timeFrame === 'hours' || timeFrame === 'hour' || timeFrame === 'h') {
+    return 1000 * 60 * 60;
+  } else if (timeFrame === 'days' || timeFrame === 'day' || timeFrame === 'd') {
+    return 1000 * 60 * 60 * 24;
+  } else if (timeFrame === 'weeks' || timeFrame === 'week' || timeFrame === 'w') {
+    return 1000 * 60 * 60 * 24 * 7;
+  } else if (timeFrame === '' || timeFrame === undefined) {
+    return 1000;
+  } else {
+    return new Error('Not a valid measurement of time!');
+  }
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,5 +1,5 @@
 const { ApolloServer, gql } = require('apollo-server');
-import { portaraSchemaDirective } from './rateLimiter';
+import { portaraSchemaDirective } from './portara/rateLimiter';
 
 // typeDefs
 const typeDefs = gql`

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,16 +1,16 @@
 const { ApolloServer, gql } = require('apollo-server');
-import { portaraSchemaDirective } from './portara/portaraDirective';
+import portaraSchemaDirective from './portara/portaraSchemaDirective';
 
 // typeDefs
 const typeDefs = gql`
-  directive @portara(limit: Int!, per: ID!) on FIELD_DEFINITION | OBJECT 
+  directive @portara(limit: Int!, per: ID!, throttle: ID!) on FIELD_DEFINITION | OBJECT 
 
   type Query {
     test: String!
   }
-  type Mutation  @portara(limit: 8, per: 10){
-    hello: String! #@portara(limit: 2, per: "10")
-    bye: String! #@portara(limit: 2)
+  type Mutation  @portara(limit: 8, per: 10, throttle: 0){
+    hello: String! @portara(limit: 2, per: "10 seconds", throttle: 0)
+    bye: String! 
   }
 `;
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,5 +1,5 @@
 const { ApolloServer, gql } = require('apollo-server');
-import { portaraSchemaDirective } from './portara/rateLimiter';
+import { portaraSchemaDirective } from './portara/portaraDirective';
 
 // typeDefs
 const typeDefs = gql`


### PR DESCRIPTION
Problem:  Added additional functionality to include optional throttling instead of directly blocking requests made to GraphQL resolvers.

Solution:  Reorganized and refactored our original rate limiter functionality.  Added throttling function through the directive to "slow" a request down based in the timeframe desired by the host of the server.

Future refactoring may be required along with Jest testing the throttling functionality.