### PR TITLE
Added throttle functionality to portara. Added jest test to test the …

### DIFF
--- a/server/__tests__/rateLimit.test.ts
+++ b/server/__tests__/rateLimit.test.ts
@@ -175,7 +175,7 @@ describe('Redis connection and functionality are performing', () => {
 
 // ---------------------------------------------------------------------
 
-describe('rate limit test using @portara decorator', () => {
+describe('test to see if rate limiter returns the correct value or the expected error message when decorating @portara on field or an object', () => {
 
   const typeDefs = gql`
   directive @portara(limit: Int!, per: ID!, throttle: ID!) on FIELD_DEFINITION | OBJECT 
@@ -225,7 +225,7 @@ describe('rate limit test using @portara decorator', () => {
 
   it('field resolver should return original return value', async () => {
     const response1 = await graphql(schema, 'mutation { hello }', null, { req: { ip: "127.0.0.13" } });
-    console.log(response1)
+
     expect(response1.data!.hello).toBe("Hello World");
   })
 
@@ -263,4 +263,72 @@ describe('rate limit test using @portara decorator', () => {
 
     expect(didWeLogError.errors![0].message).toContain('You have exceeded');
   })
+
+
+})
+
+
+describe('test to see if throttler returns the correct value at the right time when decorating @portara on field or an object', () => {
+
+  const typeDefs = gql`
+  directive @portara(limit: Int!, per: ID!, throttle: ID!) on FIELD_DEFINITION | OBJECT 
+
+  type Query {
+    test: String!
+  }
+  type Mutation @portara(limit: 4, per: 8, throttle: "1s") {
+    add: Int! @portara(limit: 2, per: "8 seconds", throttle: "1s")
+    minus: Int! 
+  }
+`;
+  let addCounter = 0;
+  let minusCounter = 5;
+  const resolvers = {
+    Query: {
+      test: (parent, args, context, info) => {
+        return 'Test'
+      }
+    },
+    Mutation: {
+      add: (parent, args, context, info) => {
+        return addCounter += 1;
+      },
+      minus: (parent, args, context, info) => {
+        return minusCounter -= 1;
+      },
+    },
+  };
+
+  const schema = makeExecutableSchema({
+    typeDefs,
+    resolvers,
+    resolverValidationOptions,
+    schemaDirectives: {
+      portara: portaraSchemaDirective,
+    },
+  })
+
+  it('field resolver should throttle 1 time after hitting the limit, time taken should be greater than or equal to 1000', async () => {
+    const t0 = performance.now()
+    await graphql(schema, 'mutation { add }', null, { req: { ip: "127.0.0.22" } });
+    await graphql(schema, 'mutation { add }', null, { req: { ip: "127.0.0.22" } });
+    const response = await graphql(schema, 'mutation { add }', null, { req: { ip: "127.0.0.22" } });
+    expect(response.data!.add).toBe(3)
+    const t1 = performance.now()
+    expect(t1 - t0).toBeGreaterThanOrEqual(1000)
+
+  })
+
+  it('object resolver should throttle 2 times after hitting the limit, time taken should be greater than or equal to 2000', async () => {
+    const t0 = performance.now()
+    for (let i = 0; i < 5; i++) {
+      await graphql(schema, 'mutation { minus }', null, { req: { ip: "127.0.0.22" } });
+    }
+    const response = await graphql(schema, 'mutation { minus }', null, { req: { ip: "127.0.0.22" } });
+    expect(response.data!.minus).toBe(-1)
+    const t1 = performance.now()
+    expect(t1 - t0).toBeGreaterThanOrEqual(2000)
+  })
+
+
 })

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['./setup.js'],
 };

--- a/server/server.ts
+++ b/server/server.ts
@@ -8,8 +8,8 @@ const typeDefs = gql`
   type Query {
     test: String!
   }
-  type Mutation  @portara(limit: 8, per: 10, throttle: 0){
-    hello: String! @portara(limit: 2, per: "10 seconds", throttle: 0)
+  type Mutation  @portara(limit: 4, per: 10, throttle: "500ms"){
+    hello: String! @portara(limit: 2, per: "10 seconds", throttle: "500 ms")
     bye: String! 
   }
 `;

--- a/server/setup.js
+++ b/server/setup.js
@@ -1,0 +1,1 @@
+global.performance = require('perf_hooks').performance;


### PR DESCRIPTION
Finished adding throttle functionality, applicable to object now, to our directive.

Added Jest testing to time the throttled time by using the performance.now() method.  Had to add setupFilesAfterEnv: ['./jest.setup.js'] into the jest.config.js.  Had to also set up a setup.js file to give Jest access to the performance.now() method

Future functionality to add: add the ability to not need to use redis, frontend & backend testing expanded to test rate limiter & throttler with ease, need to also upload new updated tool to npmjs as well as with a updated ReadMe.